### PR TITLE
Expose MaxPrefixPerNode as var

### DIFF
--- a/patricia/children.go
+++ b/patricia/children.go
@@ -5,12 +5,11 @@
 
 package patricia
 
-const (
-	// Max prefix length that is kept in a single trie node.
-	MaxPrefixPerNode = 10
-	// Max children to keep in a node in the sparse mode.
-	MaxChildrenPerSparseNode = 8
-)
+// Max prefix length that is kept in a single trie node.
+var MaxPrefixPerNode = 10
+
+// Max children to keep in a node in the sparse mode.
+const MaxChildrenPerSparseNode = 8
 
 type childList interface {
 	length() int


### PR DESCRIPTION
Changing this variable can have a huge impact on performance in some cases.
We in dotcloud/docker#6657 want to use your package and because all strings that we want to store have length 64 it will be pretty cool have ability to change MaxPrefixPerNode.
Here benchmarks for our `TruncIndex`:

```
bin/benchcmp prefix_10.txt prefix_64.txt                                                                    
benchmark                        old ns/op     new ns/op     delta       
BenchmarkTruncIndexAdd100        519957        175700        -66.21%     
BenchmarkTruncIndexAdd250        1401300       522519        -62.71%     
BenchmarkTruncIndexAdd500        2938667       1047919       -64.34%     
BenchmarkTruncIndexGet100        165660        127577        -22.99%     
BenchmarkTruncIndexGet250        436459        333950        -23.49%     
BenchmarkTruncIndexGet500        920812        691175        -24.94%     
BenchmarkTruncIndexDelete100     101162        96131         -4.97%      
BenchmarkTruncIndexDelete250     319886        230664        -27.89%     
BenchmarkTruncIndexDelete500     524306        504612        -3.76%      
BenchmarkTruncIndexNew100        499847        160208        -67.95%     
BenchmarkTruncIndexNew250        1350024       464970        -65.56%     
BenchmarkTruncIndexNew500        2856532       990191        -65.34%     
BenchmarkTruncIndexAddGet100     3944896       1717451       -56.46%     
BenchmarkTruncIndexAddGet250     3932681       1711997       -56.47%     
BenchmarkTruncIndexAddGet500     4776814       1707048       -64.26%     

benchmark                        old allocs     new allocs     delta       
BenchmarkTruncIndexAdd100        2352           528            -77.55%     
BenchmarkTruncIndexAdd250        5926           1395           -76.46%     
BenchmarkTruncIndexAdd500        11922          2870           -75.93%     
BenchmarkTruncIndexGet100        746            700            -6.17%      
BenchmarkTruncIndexGet250        1854           1752           -5.50%      
BenchmarkTruncIndexGet500        3665           3504           -4.39%      
BenchmarkTruncIndexDelete100     100            100            +0.00%      
BenchmarkTruncIndexDelete250     250            250            +0.00%      
BenchmarkTruncIndexDelete500     500            500            +0.00%      
BenchmarkTruncIndexNew100        2353           542            -76.97%     
BenchmarkTruncIndexNew250        5928           1382           -76.69%     
BenchmarkTruncIndexNew500        11927          2894           -75.74%     
BenchmarkTruncIndexAddGet100     15557          6360           -59.12%     
BenchmarkTruncIndexAddGet250     15568          6415           -58.79%     
BenchmarkTruncIndexAddGet500     15535          6332           -59.24%     

benchmark                        old bytes     new bytes     delta       
BenchmarkTruncIndexAdd100        136011        35583         -73.84%     
BenchmarkTruncIndexAdd250        352186        107216        -69.56%     
BenchmarkTruncIndexAdd500        708310        215194        -69.62%     
BenchmarkTruncIndexGet100        34871         31603         -9.37%      
BenchmarkTruncIndexGet250        86654         79138         -8.67%      
BenchmarkTruncIndexGet500        171168        158924        -7.15%      
BenchmarkTruncIndexDelete100     6400          6400          +0.00%      
BenchmarkTruncIndexDelete250     16000         16000         +0.00%      
BenchmarkTruncIndexDelete500     32000         32000         +0.00%      
BenchmarkTruncIndexNew100        134680        36252         -73.08%     
BenchmarkTruncIndexNew250        352005        104199        -70.40%     
BenchmarkTruncIndexNew500        710087        216844        -69.46%     
BenchmarkTruncIndexAddGet100     876360        375975        -57.10%     
BenchmarkTruncIndexAddGet250     876118        376951        -56.97%     
BenchmarkTruncIndexAddGet500     873994        372933        -57.33%     
```
