### PR TITLE
sort before walking when using sparseChildList

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,12 +70,12 @@ key = Prefix("Karel")
 fmt.Printf("Anybody called %q here? %v\n", key, trie.MatchSubtree(key))
 // Anybody called "Karel" here? true
 
-// Walk the tree.
+// Walk the tree in alphabetical order.
 trie.Visit(printItem)
+// "Karel Hynek Macha": 4
+// "Karel Macha": 3
 // "Pepa Novak": 1
 // "Pepa Sindelar": 2
-// "Karel Macha": 3
-// "Karel Hynek Macha": 4
 
 // Walk a subtree.
 trie.VisitSubtree(Prefix("Pepa"), printItem)
@@ -99,8 +99,8 @@ trie.Delete(Prefix("Karel Macha"))
 
 // Walk again.
 trie.Visit(printItem)
-// "Pepa Sindelar": 2
 // "Karel Hynek Macha": 10
+// "Pepa Sindelar": 2
 
 // Delete a subtree.
 trie.DeleteSubtree(Prefix("Pepa"))

--- a/patricia/children.go
+++ b/patricia/children.go
@@ -5,6 +5,8 @@
 
 package patricia
 
+import "sort"
+
 type childList interface {
 	length() int
 	head() *Trie
@@ -15,13 +17,28 @@ type childList interface {
 	walk(prefix *Prefix, visitor VisitorFunc) error
 }
 
+type tries []*Trie
+
+func (t tries) Len() int {
+	return len(t)
+}
+
+func (t tries) Less(i, j int) bool {
+	strings := sort.StringSlice{string(t[i].prefix), string(t[j].prefix)}
+	return strings.Less(0, 1)
+}
+
+func (t tries) Swap(i, j int) {
+	t[i], t[j] = t[j], t[i]
+}
+
 type sparseChildList struct {
-	children []*Trie
+	children tries
 }
 
 func newSparseChildList(maxChildrenPerSparseNode int) childList {
 	return &sparseChildList{
-		children: make([]*Trie, 0, maxChildrenPerSparseNode),
+		children: make(tries, 0, DefaultMaxChildrenPerSparseNode),
 	}
 }
 
@@ -76,6 +93,9 @@ func (list *sparseChildList) next(b byte) *Trie {
 }
 
 func (list *sparseChildList) walk(prefix *Prefix, visitor VisitorFunc) error {
+
+	sort.Sort(list.children)
+
 	for _, child := range list.children {
 		*prefix = append(*prefix, child.prefix...)
 		if child.item != nil {

--- a/patricia/patricia.go
+++ b/patricia/patricia.go
@@ -119,7 +119,8 @@ func (trie *Trie) MatchSubtree(key Prefix) (matched bool) {
 	return
 }
 
-// Visit calls visitor on every node containing a non-nil item.
+// Visit calls visitor on every node containing a non-nil item
+// in alphabetical order.
 //
 // If an error is returned from visitor, the function stops visiting the tree
 // and returns that error, unless it is a special error - SkipSubtree. In that

--- a/patricia/patricia_sparse_test.go
+++ b/patricia/patricia_sparse_test.go
@@ -300,10 +300,10 @@ func TestTrie_VisitReturnError(t *testing.T) {
 	someErr := errors.New("Something exploded")
 	if err := trie.Visit(func(prefix Prefix, item Item) error {
 		t.Logf("VISITING prefix=%q, item=%v", prefix, item)
-		if item.(int) == 0 {
+		if item.(int) == 3 {
 			return someErr
 		}
-		if item.(int) != 0 {
+		if item.(int) != 3 {
 			t.Errorf("Unexpected prefix encountered, %q", prefix)
 		}
 		return nil
@@ -598,10 +598,10 @@ func ExampleTrie() {
 
 	// Walk the tree.
 	trie.Visit(printItem)
+	// "Karel Hynek Macha": 4
+	// "Karel Macha": 3
 	// "Pepa Novak": 1
 	// "Pepa Sindelar": 2
-	// "Karel Macha": 3
-	// "Karel Hynek Macha": 4
 
 	// Walk a subtree.
 	trie.VisitSubtree(Prefix("Pepa"), printItem)
@@ -625,8 +625,8 @@ func ExampleTrie() {
 
 	// Walk again.
 	trie.Visit(printItem)
-	// "Pepa Sindelar": 2
 	// "Karel Hynek Macha": 10
+	// "Pepa Sindelar": 2
 
 	// Delete a subtree.
 	trie.DeleteSubtree(Prefix("Pepa"))
@@ -638,16 +638,16 @@ func ExampleTrie() {
 	// Output:
 	// "Pepa Novak" present? true
 	// Anybody called "Karel" here? true
-	// "Pepa Novak": 1
-	// "Pepa Sindelar": 2
-	// "Karel Macha": 3
 	// "Karel Hynek Macha": 4
+	// "Karel Macha": 3
+	// "Pepa Novak": 1
+	// "Pepa Sindelar": 2
 	// "Pepa Novak": 1
 	// "Pepa Sindelar": 2
 	// "Karel Hynek Macha": 10
 	// "Karel Hynek Macha": 10
-	// "Pepa Sindelar": 2
 	// "Karel Hynek Macha": 10
+	// "Pepa Sindelar": 2
 	// "Karel Hynek Macha": 10
 }
 


### PR DESCRIPTION
Patricia tree should return items in sorted manner when waking.
This patch fixes go-patricia's wrong behaviour when sparseChildList is used internally.