### PR TITLE
Fix vet warning

### DIFF
--- a/patricia/patricia_sparse_test.go
+++ b/patricia/patricia_sparse_test.go
@@ -123,7 +123,7 @@ func TestTrie_SetGet(t *testing.T) {
 		value := trie.Get(Prefix(v.key))
 		t.Logf("GET %q => %v", v.key, value)
 		if value.(int) != 10 {
-			t.Errorf("Unexpected return value, != 10", value)
+			t.Errorf("Unexpected return value, %v != 10", value)
 		}
 	}
 


### PR DESCRIPTION
patricia/patricia_sparse_test.go:126: no formatting directive in Errorf call

btw maybe you want to add `go vet` check to your drone script.