### PR TITLE
Avoid accumulating "empty" nodes

### DIFF
--- a/patricia/children.go
+++ b/patricia/children.go
@@ -41,16 +41,6 @@ type sparseChildList struct {
 	children tries
 }
 
-func (list *sparseChildList) total() int {
-	tot := 0
-	for _, child := range list.children {
-		if child != nil {
-			tot = tot + child.total()
-		}
-	}
-	return tot
-}
-
 func newSparseChildList(maxChildrenPerSparseNode int) childList {
 	return &sparseChildList{
 		children: make(tries, 0, maxChildrenPerSparseNode),
@@ -133,6 +123,16 @@ func (list *sparseChildList) walk(prefix *Prefix, visitor VisitorFunc) error {
 	}
 
 	return nil
+}
+
+func (list *sparseChildList) total() int {
+	tot := 0
+	for _, child := range list.children {
+		if child != nil {
+			tot = tot + child.total()
+		}
+	}
+	return tot
 }
 
 func (list *sparseChildList) print(w io.Writer, indent int) {

--- a/patricia/children.go
+++ b/patricia/children.go
@@ -5,7 +5,10 @@
 
 package patricia
 
-import "sort"
+import (
+	"io"
+	"sort"
+)
 
 type childList interface {
 	length() int
@@ -15,6 +18,8 @@ type childList interface {
 	remove(child *Trie)
 	next(b byte) *Trie
 	walk(prefix *Prefix, visitor VisitorFunc) error
+	print(w io.Writer, indent int)
+	total() int
 }
 
 type tries []*Trie
@@ -34,6 +39,16 @@ func (t tries) Swap(i, j int) {
 
 type sparseChildList struct {
 	children tries
+}
+
+func (list *sparseChildList) total() int {
+	tot := 0
+	for _, child := range list.children {
+		if child != nil {
+			tot = tot + child.total()
+		}
+	}
+	return tot
 }
 
 func newSparseChildList(maxChildrenPerSparseNode int) childList {
@@ -118,6 +133,14 @@ func (list *sparseChildList) walk(prefix *Prefix, visitor VisitorFunc) error {
 	}
 
 	return nil
+}
+
+func (list *sparseChildList) print(w io.Writer, indent int) {
+	for _, child := range list.children {
+		if child != nil {
+			child.print(w, indent)
+		}
+	}
 }
 
 type denseChildList struct {
@@ -241,4 +264,22 @@ func (list *denseChildList) walk(prefix *Prefix, visitor VisitorFunc) error {
 	}
 
 	return nil
+}
+
+func (list *denseChildList) print(w io.Writer, indent int) {
+	for _, child := range list.children {
+		if child != nil {
+			child.print(w, indent)
+		}
+	}
+}
+
+func (list *denseChildList) total() int {
+	tot := 0
+	for _, child := range list.children {
+		if child != nil {
+			tot = tot + child.total()
+		}
+	}
+	return tot
 }

--- a/patricia/patricia.go
+++ b/patricia/patricia.go
@@ -262,7 +262,7 @@ func (trie *Trie) Delete(key Prefix) (deleted bool) {
 	}
 
 	// Remove the node if it has no items.
-	if node.size() == 0 {
+	if node.empty() {
 		parent.children.remove(node)
 	}
 
@@ -302,6 +302,17 @@ func (trie *Trie) DeleteSubtree(prefix Prefix) (deleted bool) {
 }
 
 // Internal helper methods -----------------------------------------------------
+
+func (trie *Trie) empty() bool {
+	isEmpty := true
+
+	trie.walk(nil, func(prefix Prefix, item Item) error {
+		isEmpty = false
+		return SkipSubtree
+	})
+
+	return isEmpty
+}
 
 func (trie *Trie) put(key Prefix, item Item, replace bool) (inserted bool) {
 	// Nil prefix not allowed.

--- a/patricia/patricia_dense_test.go
+++ b/patricia/patricia_dense_test.go
@@ -6,10 +6,13 @@
 package patricia
 
 import (
+	"runtime"
 	"testing"
 )
 
 // Tests -----------------------------------------------------------------------
+
+const overhead = 256
 
 func TestTrie_InsertDense(t *testing.T) {
 	trie := NewTrie()
@@ -158,4 +161,64 @@ func TestTrie_DeleteDense(t *testing.T) {
 			t.Errorf("Unexpected return value, expected=%v, got=%v", v.retVal, ok)
 		}
 	}
+}
+
+func TestTrie_DeleteLeakage(t *testing.T) {
+	trie := NewTrie()
+
+	data := []testData{
+		{"aba", 0, success},
+		{"abb", 1, success},
+		{"abc", 2, success},
+		{"abd", 3, success},
+		{"abe", 4, success},
+		{"abf", 5, success},
+		{"abg", 6, success},
+		{"abh", 7, success},
+		{"abi", 8, success},
+		{"abj", 9, success},
+		{"abk", 0, success},
+		{"abl", 1, success},
+		{"abm", 2, success},
+		{"abn", 3, success},
+		{"abo", 4, success},
+		{"abp", 5, success},
+		{"abq", 6, success},
+		{"abr", 7, success},
+		{"abs", 8, success},
+		{"abt", 9, success},
+		{"abu", 0, success},
+		{"abv", 1, success},
+		{"abw", 2, success},
+		{"abx", 3, success},
+		{"aby", 4, success},
+		{"abz", 5, success},
+	}
+
+	oldBytes := heapAllocatedBytes()
+
+	for _, v := range data {
+		if ok := trie.Insert(Prefix(v.key), v.value); ok != v.retVal {
+			t.Errorf("Unexpected return value, expected=%v, got=%v", v.retVal, ok)
+		}
+	}
+
+	for _, v := range data {
+		if ok := trie.Delete([]byte(v.key)); ok != v.retVal {
+			t.Errorf("Unexpected return value, expected=%v, got=%v", v.retVal, ok)
+		}
+	}
+
+	if newBytes := heapAllocatedBytes(); newBytes > oldBytes+overhead {
+		t.Logf("Size=%d, Total=%d, Trie state:\n%s\n", trie.size(), trie.total(), trie.dump())
+		t.Errorf("Heap space leak, grew from %d to %d bytes\n", oldBytes, newBytes)
+	}
+}
+
+func heapAllocatedBytes() uint64 {
+	runtime.GC()
+
+	ms := runtime.MemStats{}
+	runtime.ReadMemStats(&ms)
+	return ms.Alloc
 }

--- a/patricia/patricia_dense_test.go
+++ b/patricia/patricia_dense_test.go
@@ -163,7 +163,7 @@ func TestTrie_DeleteDense(t *testing.T) {
 	}
 }
 
-func TestTrie_DeleteLeakage(t *testing.T) {
+func TestTrie_DeleteLeakageDense(t *testing.T) {
 	trie := NewTrie()
 
 	data := []testData{

--- a/patricia/patricia_sparse_test.go
+++ b/patricia/patricia_sparse_test.go
@@ -417,7 +417,7 @@ func TestParticiaTrie_Delete(t *testing.T) {
 	}
 }
 
-func TestParticiaTrie_DeleteLeakage(t *testing.T) {
+func TestParticiaTrie_DeleteLeakageSparse(t *testing.T) {
 	trie := NewTrie()
 
 	data := []testData{

--- a/patricia/patricia_sparse_test.go
+++ b/patricia/patricia_sparse_test.go
@@ -417,6 +417,35 @@ func TestParticiaTrie_Delete(t *testing.T) {
 	}
 }
 
+func TestParticiaTrie_DeleteLeakage(t *testing.T) {
+	trie := NewTrie()
+
+	data := []testData{
+		{"Pepan", "Pepan Zdepan", success},
+		{"Honza", "Honza Novak", success},
+		{"Jenik", "Jenik Poustevnicek", success},
+	}
+
+	oldBytes := heapAllocatedBytes()
+
+	for _, v := range data {
+		if ok := trie.Insert([]byte(v.key), v.value); ok != v.retVal {
+			t.Fatalf("Unexpected return value, expected=%v, got=%v", v.retVal, ok)
+		}
+	}
+
+	for _, v := range data {
+		if ok := trie.Delete([]byte(v.key)); ok != v.retVal {
+			t.Errorf("Unexpected return value, expected=%v, got=%v", v.retVal, ok)
+		}
+	}
+
+	if newBytes := heapAllocatedBytes(); newBytes > oldBytes+overhead {
+		t.Logf("Size=%d, Total=%d, Trie state:\n%s\n", trie.size(), trie.total(), trie.dump())
+		t.Errorf("Heap space leak, grew from %d to %d bytes\n", oldBytes, newBytes)
+	}
+}
+
 func TestParticiaTrie_DeleteNonExistent(t *testing.T) {
 	trie := NewTrie()
 


### PR DESCRIPTION
This commit includes tests which show that adding entries to a trie
and deleting them all leaves "empty" nodes (i.e. those with a nil
item) around. In long-running processes, this leads to excessive
memory usage. The fix is to prune some unnecessary nodes during
deletion.

Note: there is a trade-off against performance. We attempt to prune a
node which has been deleted, but we don't attempt to prune its
ancestors. The latter approach made performance of the "random kitchen
sink" test worse by at least two orders of magnitude.

Also note that the diagnostic methods added here could be stripped out if
this is preferred.

@goonzoid & @glyn