### PR TITLE
Show difference in bytes for space leak tests

### DIFF
--- a/patricia/patricia_dense_test.go
+++ b/patricia/patricia_dense_test.go
@@ -211,7 +211,7 @@ func TestTrie_DeleteLeakageDense(t *testing.T) {
 
 	if newBytes := heapAllocatedBytes(); newBytes > oldBytes+overhead {
 		t.Logf("Size=%d, Total=%d, Trie state:\n%s\n", trie.size(), trie.total(), trie.dump())
-		t.Errorf("Heap space leak, grew from %d to %d bytes\n", oldBytes, newBytes)
+		t.Errorf("Heap space leak, grew %d bytes (%d to %d)\n", newBytes-oldBytes, oldBytes, newBytes)
 	}
 }
 

--- a/patricia/patricia_sparse_test.go
+++ b/patricia/patricia_sparse_test.go
@@ -442,7 +442,7 @@ func TestParticiaTrie_DeleteLeakageSparse(t *testing.T) {
 
 	if newBytes := heapAllocatedBytes(); newBytes > oldBytes+overhead {
 		t.Logf("Size=%d, Total=%d, Trie state:\n%s\n", trie.size(), trie.total(), trie.dump())
-		t.Errorf("Heap space leak, grew from %d to %d bytes\n", oldBytes, newBytes)
+		t.Errorf("Heap space leak, grew %d bytes (from %d to %d)\n", newBytes-oldBytes, oldBytes, newBytes)
 	}
 }
 


### PR DESCRIPTION
Minor change in error message to show the size of the leak so that the user (developer) would not have to perform calculation newBytes-oldBytes to figure it out.  Sample output with the change:
```
--- FAIL: TestParticiaTrie_DeleteLeakageSparse (0.00s)
	patricia_sparse_test.go:444: Size=0, Total=1, Trie state:
		 <nil>
	patricia_sparse_test.go:445: Heap space leak, grew 1808 bytes (from 132704 to 134512)
```