### PR TITLE
Fuzzy/Substring finding

### DIFF
--- a/patricia/children.go
+++ b/patricia/children.go
@@ -81,7 +81,7 @@ func (list *sparseChildList) add(child *Trie) childList {
 }
 
 func (list sparseChildList) combinedMask() uint64 {
-	var mask uint64 = 0
+	var mask uint64
 	for _, child := range list.children {
 		if child != nil {
 			mask |= child.mask
@@ -359,7 +359,7 @@ func (list *denseChildList) print(w io.Writer, indent int) {
 }
 
 func (list denseChildList) combinedMask() uint64 {
-	var mask uint64 = 0
+	var mask uint64
 	for _, child := range list.children {
 		if child != nil {
 			mask |= child.mask

--- a/patricia/children.go
+++ b/patricia/children.go
@@ -18,6 +18,8 @@ type childList interface {
 	remove(b byte)
 	replace(b byte, child *Trie)
 	next(b byte) *Trie
+	combinedMask() uint64
+	getChildren() []*Trie
 	walk(prefix *Prefix, visitor VisitorFunc) error
 	print(w io.Writer, indent int)
 	clone() childList
@@ -43,6 +45,16 @@ type sparseChildList struct {
 	children tries
 }
 
+func (list *sparseChildList) getChildren() []*Trie {
+	children := make([]*Trie, 0, len(list.children))
+	for _, c := range list.children {
+		if c != nil {
+			children = append(children, c)
+		}
+	}
+	return children
+}
+
 func newSparseChildList(maxChildrenPerSparseNode int) childList {
 	return &sparseChildList{
 		children: make(tries, 0, maxChildrenPerSparseNode),
@@ -66,6 +78,16 @@ func (list *sparseChildList) add(child *Trie) childList {
 
 	// Otherwise we have to transform to the dense list type.
 	return newDenseChildList(list, child)
+}
+
+func (list sparseChildList) combinedMask() uint64 {
+	var mask uint64 = 0
+	for _, child := range list.children {
+		if child != nil {
+			mask |= child.mask
+		}
+	}
+	return mask
 }
 
 func (list *sparseChildList) remove(b byte) {
@@ -169,6 +191,16 @@ type denseChildList struct {
 	numChildren int
 	headIndex   int
 	children    []*Trie
+}
+
+func (list *denseChildList) getChildren() []*Trie {
+	children := make([]*Trie, 0, len(list.children))
+	for _, c := range list.children {
+		if c != nil {
+			children = append(children, c)
+		}
+	}
+	return children
 }
 
 func newDenseChildList(list *sparseChildList, child *Trie) childList {
@@ -324,6 +356,16 @@ func (list *denseChildList) print(w io.Writer, indent int) {
 			child.print(w, indent)
 		}
 	}
+}
+
+func (list denseChildList) combinedMask() uint64 {
+	var mask uint64 = 0
+	for _, child := range list.children {
+		if child != nil {
+			mask |= child.mask
+		}
+	}
+	return mask
 }
 
 func (list *denseChildList) clone() childList {

--- a/patricia/patricia.go
+++ b/patricia/patricia.go
@@ -351,9 +351,9 @@ func overlapLength(prefix, query Prefix) int {
 		startLength = len(prefix)
 	}
 	for i := startLength; i > 0; i-- {
-		suffix := prefix[:len(prefix)-i]
-		querySuffix := query[:len(query)-i]
-		if bytes.Equal(suffix, querySuffix) {
+		suffix := prefix[len(prefix)-i:]
+		queryPrefix := query[:i]
+		if bytes.Equal(suffix, queryPrefix) {
 			return i
 		}
 	}

--- a/patricia/patricia.go
+++ b/patricia/patricia.go
@@ -218,7 +218,8 @@ func (node *Trie) VisitFuzzy(partial Prefix, visitor FuzzyVisitorFunc) error {
 			continue
 		}
 
-		matchCount, skipped := fuzzyMatchCount(p.node.prefix, partial[p.idx:])
+		matchCount, skipped := fuzzyMatchCount(p.node.prefix,
+			partial[p.idx:], p.idx)
 		p.idx += matchCount
 		if p.idx != 0 {
 			p.skipped += skipped
@@ -262,15 +263,18 @@ func (node *Trie) VisitFuzzy(partial Prefix, visitor FuzzyVisitorFunc) error {
 	return nil
 }
 
-func fuzzyMatchCount(prefix, query Prefix) (count, skipped int) {
+func fuzzyMatchCount(prefix, query Prefix, idx int) (count, skipped int) {
 	for i := 0; i < len(prefix); i++ {
+
 		if prefix[i] != query[count] {
-			skipped++
+			if count+idx > 0 {
+				skipped++
+			}
 			continue
 		}
 
 		count++
-		if count == len(query) {
+		if idx+count >= len(query) {
 			return
 		}
 	}

--- a/patricia/patricia.go
+++ b/patricia/patricia.go
@@ -274,7 +274,7 @@ func fuzzyMatchCount(prefix, query Prefix, idx int) (count, skipped int) {
 		}
 
 		count++
-		if idx+count >= len(query) {
+		if count >= len(query) {
 			return
 		}
 	}

--- a/patricia/patricia_test.go
+++ b/patricia/patricia_test.go
@@ -269,6 +269,18 @@ func TestTrie_FuzzyCollect(t *testing.T) {
 				{"Honza", 3},
 			},
 		},
+		{
+			"nza",
+			[]testResult{
+				{"Honza", 0},
+			},
+		},
+		{
+			"eni",
+			[]testResult{
+				{"Jenik", 0},
+			},
+		},
 	}
 
 	for _, data := range testQueries {

--- a/patricia/patricia_test.go
+++ b/patricia/patricia_test.go
@@ -13,20 +13,6 @@ import (
 
 // Tests -----------------------------------------------------------------------
 
-func TestTrie_ConstructorOptions(t *testing.T) {
-	trie := NewTrie(MaxPrefixPerNode(16), MaxChildrenPerSparseNode(10))
-
-	if trie.maxPrefixPerNode != 16 {
-		t.Errorf("Unexpected trie.maxPrefixPerNode value, expected=%v, got=%v",
-			16, trie.maxPrefixPerNode)
-	}
-
-	if trie.maxChildrenPerSparseNode != 10 {
-		t.Errorf("Unexpected trie.maxChildrenPerSparseNode value, expected=%v, got=%v",
-			10, trie.maxChildrenPerSparseNode)
-	}
-}
-
 func TestTrie_GetNonexistentPrefix(t *testing.T) {
 	trie := NewTrie()
 


### PR DESCRIPTION
Hi,

I modified your projct for a project of mine, I thought maybe you like the changes and want to merge them into your repo.

I introduced some methods to make relatively fast fuzzy/substring finding possible. 
The methods use a 64 bit bitmask for every node of the trie which describes the set of character that are stored in the subtree. Using this bitmask, only the parts of the tree which potentially contain all of the query are evaluated, which makes for good performance.

The obvious drawback of this, of course, are the additional 8 byte of memory usage per node. The bitmask could be reduced to 4 bytes if we don't differentiate between uppercase and lowercase letters, but I personally have found that the memory overhead works for my use case. 

If you are generally interested to merge these changes, I'd be happy to clean up the code and squash the commits as required.