### PR TITLE
update the Godoc pointer to v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # go-patricia #
 
-**Documentation**: [GoDoc](http://godoc.org/github.com/tchap/go-patricia/patricia)<br />
+**Documentation**: [GoDoc](https://pkg.go.dev/github.com/tchap/go-patricia/v2/patricia)<br />
 **Test Coverage**: [![Coverage
 Status](https://coveralls.io/repos/tchap/go-patricia/badge.png)](https://coveralls.io/r/tchap/go-patricia)
 


### PR DESCRIPTION
PR updates the Godoc pointer to pkg.go.dev and v2 - to be in sync with the README.md text:
```
Import the package from GitHub first. 

   import "github.com/tchap/go-patricia/v2/patricia"
```