### PR TITLE
add a GoDoc badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # go-patricia #
 
-**Documentation**: [![Go Reference](https://pkg.go.dev/badge/github.com/tchap/go-patricia/v2/patricia.svg)](https://pkg.go.dev/github.com/tchap/go-patricia/v2/patricia) <br />
-**Test Coverage**: [![Coverage
+[![Go Reference](https://pkg.go.dev/badge/github.com/tchap/go-patricia/v2/patricia.svg)](https://pkg.go.dev/github.com/tchap/go-patricia/v2/patricia)[![Coverage
 Status](https://coveralls.io/repos/tchap/go-patricia/badge.png)](https://coveralls.io/r/tchap/go-patricia)
 
 ## About ##

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # go-patricia #
 
-**Documentation**: [GoDoc](https://pkg.go.dev/github.com/tchap/go-patricia/v2/patricia)<br />
+**Documentation**: [![Go Reference](https://pkg.go.dev/badge/github.com/tchap/go-patricia/v2/patricia.svg)](https://pkg.go.dev/github.com/tchap/go-patricia/v2/patricia) <br />
 **Test Coverage**: [![Coverage
 Status](https://coveralls.io/repos/tchap/go-patricia/badge.png)](https://coveralls.io/r/tchap/go-patricia)
 


### PR DESCRIPTION
PR adds a GoDoc badge generated with https://pkg.go.dev/badge/ (linked from https://pkg.go.dev/about "Creating a badge").

@tchap - maybe we can do without the `Documentation` and `Test coverage` labels and just put two badges next to each other? something like on https://github.com/vishvananda/netlink#readm
![Screenshot 2022-08-04 at 19 38 19](https://user-images.githubusercontent.com/31205/182915226-4f04a0f6-2d40-42e6-b4eb-d5f2df4f8284.png).  Let me know what you prefer 😄 
e