### PR TITLE
fix: return trie if child is nil during compact to avoid nil-pointer panic

### DIFF
--- a/patricia/patricia.go
+++ b/patricia/patricia.go
@@ -465,7 +465,7 @@ func (trie *Trie) compact() *Trie {
 	// If any item is set, we cannot compact since we want to retain
 	// the ability to do searching by key. This makes compaction less usable,
 	// but that simply cannot be avoided.
-	if trie.item != nil || child.item != nil {
+	if child == nil || trie.item != nil || child.item != nil {
 		return trie
 	}
 

--- a/patricia/patricia_sparse_test.go
+++ b/patricia/patricia_sparse_test.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -628,6 +629,19 @@ func TestTrie_compact(t *testing.T) {
 			}
 		}
 		return nil
+	})
+}
+
+func TestTrie_compactChildrenHeadIsNil(t *testing.T) {
+	testName := "children head is nil"
+	t.Run(testName, func(t *testing.T) {
+		trie := NewTrie()
+		trie.children.add(nil)
+
+		// should return trie itself
+		if got := trie.compact(); !reflect.DeepEqual(got, trie) {
+			t.Errorf("compact() = %v, want %v", got, trie)
+		}
 	})
 }
 


### PR DESCRIPTION
Issue link

https://github.com/tchap/go-patricia/issues/41